### PR TITLE
fix: trim leading zeroes in `r`, `s` values in signatures

### DIFF
--- a/lib/eth/transaction/signer.ex
+++ b/lib/eth/transaction/signer.ex
@@ -102,9 +102,7 @@ defmodule ETH.Transaction.Signer do
     sign_transaction_list(transaction_list, decoded_private_key)
   end
 
-  defp trim_leading_zeroes(binary) do
-    String.trim_leading(binary, <<0>>)
-  end
+  defp trim_leading_zeroes(binary), do: String.trim_leading(binary, <<0>>)
 
   defp sign_transaction_list(
          transaction_list = [

--- a/lib/eth/transaction/signer.ex
+++ b/lib/eth/transaction/signer.ex
@@ -34,7 +34,7 @@ defmodule ETH.Transaction.Signer do
 
     target_list
     |> ExRLP.encode()
-    |> ExKeccak.hash_256
+    |> ExKeccak.hash_256()
   end
 
   def hash_transaction(
@@ -102,6 +102,10 @@ defmodule ETH.Transaction.Signer do
     sign_transaction_list(transaction_list, decoded_private_key)
   end
 
+  defp trim_leading_zeroes(binary) do
+    String.trim_leading(binary, <<0>>)
+  end
+
   defp sign_transaction_list(
          transaction_list = [
            nonce,
@@ -130,8 +134,17 @@ defmodule ETH.Transaction.Signer do
 
     sig_v = if chain_id_int > 0, do: initial_v + (chain_id_int * 2 + 8), else: initial_v
 
-
-    [nonce, gas_price, gas_limit, to, value, data, <<sig_v>>, sig_r, sig_s]
+    [
+      nonce,
+      gas_price,
+      gas_limit,
+      to,
+      value,
+      data,
+      <<sig_v>>,
+      trim_leading_zeroes(sig_r),
+      trim_leading_zeroes(sig_s)
+    ]
     |> ExRLP.encode()
   end
 end


### PR DESCRIPTION
According to the [Ethereum Yellowpaper](https://ethereum.github.io/yellowpaper/paper.pdf#page=19): 

> When interpreting RLP data, if an expected fragment is decoded as a scalar and leading zeroes are found in the byte
> sequence, clients are required to consider it non-canonical and treat it in the same manner as otherwise invalid RLP data,
> dismissing it completely.

Thus, the `r` and `s` in signatures values must have leading zeroes trimmed. Currently we don't have them trimmed which occasionally leads to transactions being rejected when broadcasting. This PR addresses this.

I wasn't able to run the tests successfully using the instructions provided in the main repo's README and some of them don't even do ganache calls, which suggest the test suite is out of date or I made something wrong? 
